### PR TITLE
fix: ensure unique keys for SVG annotations to prevent remounting issues

### DIFF
--- a/packages/specviz/src/note.tsx
+++ b/packages/specviz/src/note.tsx
@@ -414,7 +414,24 @@ export function Annotation(props: AnnotationProps): JSX.Element {
     props.selected,
     viewport.state.zoom,
   ])
-  return <>{svgProps && render?.({ ...props, svgProps })}</>
+
+  if (!svgProps) return <></>
+
+  // Create a unique key based on the actual width and height of the annotation and zoom
+  const svgKey = `${props.region.id}-${props.region.width}-${props.region.height}-${viewport.state.zoom.x}-${viewport.state.zoom.y}`
+
+  // Wrap the render result to add the key
+  const wrappedRender = (props: AnnotationProps) => {
+    const result = render?.(props)
+    if (!result) return null
+    // If the result is an SVG, add a key to force remount
+    if (result.type === 'svg') {
+      return R.cloneElement(result, { key: svgKey })
+    }
+    return result
+  }
+
+  return <>{wrappedRender({ ...props, svgProps })}</>
 }
 
 // internals


### PR DESCRIPTION
# Fix Chrome SVG Cache Issue in Annotations

## Problem
In Chrome, SVG annotations were experiencing caching issues where changes to dimensions or zoom levels weren't properly reflected in the rendered output. This was causing visual inconsistencies and stale renders when the viewport or annotation dimensions changed.

## Solution
This PR addresses the issue by:
1. Adding unique keys to SVG annotations based on:
   - Region ID
   - Region dimensions (width and height)
   - Viewport zoom level (x and y)
2. Implementing a wrapper function that ensures SVG elements are properly remounted when their dimensions or the zoom level changes
3. Adding proper null checks and type safety for the render result

## Changes
- Modified `Annotation` component in `note.tsx` to generate unique keys for SVG elements
- Added a `wrappedRender` function to handle SVG element remounting
- Improved type safety and null handling for render results

## Testing
The changes have been tested in Chrome and should resolve the caching issues while maintaining proper rendering behavior in other browsers.

## Related Issues
- Fixes SVG caching issues in Chrome
- Ensures consistent rendering across viewport changes